### PR TITLE
Fix cookie security and simplify API services

### DIFF
--- a/outsourcing-platform/src/lib/api/auth.ts
+++ b/outsourcing-platform/src/lib/api/auth.ts
@@ -12,71 +12,55 @@ import {
 export class AuthService {
   // Login user
   static async login(credentials: LoginRequest): Promise<AuthResponse> {
-    try {
-      const response = await authApi.post('/login', credentials);
-      const authData: AuthResponse = response.data;
-      
-      setAuthToken(authData.token);
-      setRefreshToken(authData.refreshToken);
-      
-      return authData;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.post('/login', credentials);
+    const authData: AuthResponse = response.data;
+
+    setAuthToken(authData.token);
+    setRefreshToken(authData.refreshToken);
+
+    return authData;
   }
 
   // Register client
   static async registerClient(userData: RegisterClientRequest): Promise<AuthResponse> {
-    try {
-      const response = await authApi.post('/register/client', {
-        email: userData.email,
-        password: userData.password,
-        firstName: userData.firstName,
-        lastName: userData.lastName,
-        phone: userData.phone,
-      });
-      
-      const authData: AuthResponse = response.data;
-      
-      setAuthToken(authData.token);
-      setRefreshToken(authData.refreshToken);
-      
-      return authData;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.post('/register/client', {
+      email: userData.email,
+      password: userData.password,
+      firstName: userData.firstName,
+      lastName: userData.lastName,
+      phone: userData.phone,
+    });
+
+    const authData: AuthResponse = response.data;
+
+    setAuthToken(authData.token);
+    setRefreshToken(authData.refreshToken);
+
+    return authData;
   }
 
   // Register company
   static async registerCompany(userData: RegisterCompanyRequest): Promise<AuthResponse> {
-    try {
-      const response = await authApi.post('/register/company', {
-        email: userData.email,
-        password: userData.password,
-        companyName: userData.companyName,
-        companyDescription: userData.companyDescription,
-        phone: userData.phone,
-      });
-      
-      const authData: AuthResponse = response.data;
-      
-      setAuthToken(authData.token);
-      setRefreshToken(authData.refreshToken);
-      
-      return authData;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.post('/register/company', {
+      email: userData.email,
+      password: userData.password,
+      companyName: userData.companyName,
+      companyDescription: userData.companyDescription,
+      phone: userData.phone,
+    });
+
+    const authData: AuthResponse = response.data;
+
+    setAuthToken(authData.token);
+    setRefreshToken(authData.refreshToken);
+
+    return authData;
   }
 
   // Get current user account info
   static async getAccount(): Promise<User> {
-    try {
-      const response = await authApi.get('/account');
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.get('/account');
+    return response.data;
   }
 
   // Logout user
@@ -84,11 +68,9 @@ export class AuthService {
     try {
       await authApi.post('/logout');
     } catch (error) {
-      // Even if logout fails, clear local tokens
       console.error('Logout error:', error);
-    } finally {
-      clearTokens();
     }
+    clearTokens();
   }
 
   // Service card management (based on outsourcing-auth API)
@@ -99,46 +81,26 @@ export class AuthService {
     category: string;
     images?: string[];
   }): Promise<Service> {
-    try {
-      const response = await authApi.post('/services', serviceData);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.post('/services', serviceData);
+    return response.data;
   }
 
   static async getServiceCards(): Promise<Service[]> {
-    try {
-      const response = await authApi.get('/services');
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.get('/services');
+    return response.data;
   }
 
   static async updateServiceCard(serviceId: string, serviceData: Partial<Service>): Promise<Service> {
-    try {
-      const response = await authApi.put(`/services/${serviceId}`, serviceData);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.put(`/services/${serviceId}`, serviceData);
+    return response.data;
   }
 
   static async deleteServiceCard(serviceId: string): Promise<void> {
-    try {
-      await authApi.delete(`/services/${serviceId}`);
-    } catch (error) {
-      throw error;
-    }
+    await authApi.delete(`/services/${serviceId}`);
   }
 
   static async getServiceCard(serviceId: string): Promise<Service> {
-    try {
-      const response = await authApi.get(`/services/${serviceId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await authApi.get(`/services/${serviceId}`);
+    return response.data;
   }
 }

--- a/outsourcing-platform/src/lib/api/config.ts
+++ b/outsourcing-platform/src/lib/api/config.ts
@@ -52,7 +52,11 @@ export const getAuthToken = (): string | null => {
 };
 
 export const setAuthToken = (token: string): void => {
-  Cookies.set(TOKEN_KEY, token, { expires: 7, secure: true, sameSite: 'strict' });
+  Cookies.set(TOKEN_KEY, token, {
+    expires: 7,
+    secure: window.location.protocol === 'https:',
+    sameSite: 'strict',
+  });
 };
 
 export const getRefreshToken = (): string | null => {
@@ -60,7 +64,11 @@ export const getRefreshToken = (): string | null => {
 };
 
 export const setRefreshToken = (token: string): void => {
-  Cookies.set(REFRESH_TOKEN_KEY, token, { expires: 30, secure: true, sameSite: 'strict' });
+  Cookies.set(REFRESH_TOKEN_KEY, token, {
+    expires: 30,
+    secure: window.location.protocol === 'https:',
+    sameSite: 'strict',
+  });
 };
 
 export const clearTokens = (): void => {

--- a/outsourcing-platform/src/lib/api/database.ts
+++ b/outsourcing-platform/src/lib/api/database.ts
@@ -4,78 +4,46 @@ import { User, Company, Message, Chat } from '@/types/api';
 export class DatabaseService {
   // Users management
   static async getUsers(): Promise<User[]> {
-    try {
-      const response = await databaseApi.get('/users');
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get('/users');
+    return response.data;
   }
 
   static async getUserById(userId: string): Promise<User> {
-    try {
-      const response = await databaseApi.get(`/users/${userId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/users/${userId}`);
+    return response.data;
   }
 
   static async updateUser(userId: string, userData: Partial<User>): Promise<User> {
-    try {
-      const response = await databaseApi.put(`/users/${userId}`, userData);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.put(`/users/${userId}`, userData);
+    return response.data;
   }
 
   // Companies management
   static async getCompanies(): Promise<Company[]> {
-    try {
-      const response = await databaseApi.get('/companies');
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get('/companies');
+    return response.data;
   }
 
   static async getCompanyById(companyId: string): Promise<Company> {
-    try {
-      const response = await databaseApi.get(`/companies/${companyId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/companies/${companyId}`);
+    return response.data;
   }
 
   static async updateCompany(companyId: string, companyData: Partial<Company>): Promise<Company> {
-    try {
-      const response = await databaseApi.put(`/companies/${companyId}`, companyData);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.put(`/companies/${companyId}`, companyData);
+    return response.data;
   }
 
   // User-Company relationships
   static async getUserCompanies(userId: string): Promise<Company[]> {
-    try {
-      const response = await databaseApi.get(`/user_companies?user_id=${userId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/user_companies?user_id=${userId}`);
+    return response.data;
   }
 
   // Messages and chat functionality
   static async getMessages(userId: string): Promise<Message[]> {
-    try {
-      const response = await databaseApi.get(`/messages/${userId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/messages/${userId}`);
+    return response.data;
   }
 
   static async sendMessage(messageData: {
@@ -84,69 +52,41 @@ export class DatabaseService {
     type?: 'text' | 'image' | 'file';
     serviceId?: string;
   }): Promise<Message> {
-    try {
-      const response = await databaseApi.post('/messages', messageData);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.post('/messages', messageData);
+    return response.data;
   }
 
   static async markMessageAsRead(messageId: string): Promise<void> {
-    try {
-      await databaseApi.put(`/messages/${messageId}/read`);
-    } catch (error) {
-      throw error;
-    }
+    await databaseApi.put(`/messages/${messageId}/read`);
   }
 
   // Chat conversations
   static async getChats(userId: string): Promise<Chat[]> {
-    try {
-      const response = await databaseApi.get(`/chats?user_id=${userId}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/chats?user_id=${userId}`);
+    return response.data;
   }
 
   static async getChatMessages(chatId: string, page: number = 1, limit: number = 50): Promise<Message[]> {
-    try {
-      const response = await databaseApi.get(`/chats/${chatId}/messages?page=${page}&limit=${limit}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/chats/${chatId}/messages?page=${page}&limit=${limit}`);
+    return response.data;
   }
 
   static async createChat(participantIds: string[], serviceId?: string): Promise<Chat> {
-    try {
-      const response = await databaseApi.post('/chats', {
-        participantIds,
-        serviceId,
-      });
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.post('/chats', {
+      participantIds,
+      serviceId,
+    });
+    return response.data;
   }
 
   // Search users and companies
   static async searchUsers(query: string): Promise<User[]> {
-    try {
-      const response = await databaseApi.get(`/users/search?q=${encodeURIComponent(query)}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/users/search?q=${encodeURIComponent(query)}`);
+    return response.data;
   }
 
   static async searchCompanies(query: string): Promise<Company[]> {
-    try {
-      const response = await databaseApi.get(`/companies/search?q=${encodeURIComponent(query)}`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await databaseApi.get(`/companies/search?q=${encodeURIComponent(query)}`);
+    return response.data;
   }
 }

--- a/outsourcing-platform/src/lib/api/photos.ts
+++ b/outsourcing-platform/src/lib/api/photos.ts
@@ -4,34 +4,26 @@ import { PhotoUploadResponse } from '@/types/api';
 export class PhotosService {
   // Upload single photo
   static async uploadPhoto(file: File, metadata?: any): Promise<PhotoUploadResponse> {
-    try {
-      const formData = new FormData();
-      formData.append('photo', file);
-      
-      if (metadata) {
-        formData.append('metadata', JSON.stringify(metadata));
-      }
+    const formData = new FormData();
+    formData.append('photo', file);
 
-      const response = await photosApi.post('/photos/upload', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
-      
-      return response.data;
-    } catch (error) {
-      throw error;
+    if (metadata) {
+      formData.append('metadata', JSON.stringify(metadata));
     }
+
+    const response = await photosApi.post('/photos/upload', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    return response.data;
   }
 
   // Upload multiple photos
   static async uploadPhotos(files: File[], metadata?: any): Promise<PhotoUploadResponse[]> {
-    try {
-      const uploadPromises = files.map(file => this.uploadPhoto(file, metadata));
-      return await Promise.all(uploadPromises);
-    } catch (error) {
-      throw error;
-    }
+    const uploadPromises = files.map(file => this.uploadPhoto(file, metadata));
+    return await Promise.all(uploadPromises);
   }
 
   // Process photo (resize, optimize, etc.)
@@ -41,35 +33,23 @@ export class PhotosService {
     quality?: number;
     format?: 'jpeg' | 'png' | 'webp';
   }): Promise<PhotoUploadResponse> {
-    try {
-      const response = await photosApi.post('/photos/process', {
-        photoId,
-        ...options,
-      });
-      
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await photosApi.post('/photos/process', {
+      photoId,
+      ...options,
+    });
+
+    return response.data;
   }
 
   // Get photo metadata
   static async getPhotoMetadata(photoId: string): Promise<any> {
-    try {
-      const response = await photosApi.get(`/photos/${photoId}/metadata`);
-      return response.data;
-    } catch (error) {
-      throw error;
-    }
+    const response = await photosApi.get(`/photos/${photoId}/metadata`);
+    return response.data;
   }
 
   // Delete photo
   static async deletePhoto(photoId: string): Promise<void> {
-    try {
-      await photosApi.delete(`/photos/${photoId}`);
-    } catch (error) {
-      throw error;
-    }
+    await photosApi.delete(`/photos/${photoId}`);
   }
 
   // Get photo URL by ID


### PR DESCRIPTION
## Summary
- allow auth cookies to work over HTTP or HTTPS
- simplify AuthService, DatabaseService and PhotosService by removing useless try/catch blocks

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68459290a5b8832e9f62f19b9de2f78b