### PR TITLE
Fix search sort parameters

### DIFF
--- a/outsourcing-platform/src/lib/api/search.ts
+++ b/outsourcing-platform/src/lib/api/search.ts
@@ -85,20 +85,19 @@ export class SearchService {
       // Apply sorting
       if (params.sort) {
         switch (params.sort) {
-          case 'price_asc':
+          case 'price_low':
             services.sort((a: Service, b: Service) => a.price - b.price);
             break;
-          case 'price_desc':
+          case 'price_high':
             services.sort((a: Service, b: Service) => b.price - a.price);
             break;
-          case 'rating':
+          case 'rating_low':
+            services.sort((a: Service, b: Service) => a.rating - b.rating);
+            break;
+          case 'rating_high':
             services.sort((a: Service, b: Service) => b.rating - a.rating);
             break;
-          case 'date':
           default:
-            services.sort((a: Service, b: Service) => 
-              new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-            );
             break;
         }
       }

--- a/outsourcing-platform/src/pages/SearchPage.tsx
+++ b/outsourcing-platform/src/pages/SearchPage.tsx
@@ -28,7 +28,14 @@ const SearchPage = () => {
     // Initialize search from URL params or store
     const query = searchParams.get('q') || storeSearchParams.query || '';
     const category = searchParams.get('category') || storeSearchParams.category || '';
-    const sort = searchParams.get('sort') || storeSearchParams.sort || 'date';
+    const sort =
+      (searchParams.get('sort') as
+        | 'price_low'
+        | 'price_high'
+        | 'rating_low'
+        | 'rating_high'
+        | null)
+        ?? storeSearchParams.sort;
 
     setSearchQuery(query);
     
@@ -132,7 +139,7 @@ const SearchPage = () => {
                     Сортировка
                   </label>
                   <Select
-                    value={storeSearchParams.sort || 'date'}
+                    value={storeSearchParams.sort || ''}
                     onValueChange={(value) => handleFilterChange('sort', value)}
                   >
                     <SelectTrigger>

--- a/outsourcing-platform/src/store/servicesStore.ts
+++ b/outsourcing-platform/src/store/servicesStore.ts
@@ -49,7 +49,7 @@ const initialSearchParams: SearchParams = {
   price_to: undefined,
   location: '',
   rating: undefined,
-  sort: 'date',
+  sort: undefined,
   category: '',
   page: 1,
   limit: 12,

--- a/outsourcing-platform/src/types/api.ts
+++ b/outsourcing-platform/src/types/api.ts
@@ -53,7 +53,7 @@ export interface SearchParams {
   price_to?: number;
   location?: string;
   rating?: number;
-  sort?: 'price_asc' | 'price_desc' | 'rating' | 'date';
+  sort?: 'price_low' | 'price_high' | 'rating_low' | 'rating_high';
   category?: string;
   page?: number;
   limit?: number;
@@ -167,8 +167,9 @@ export type ServiceCategory = typeof SERVICE_CATEGORIES[number];
 
 // Sort options
 export const SORT_OPTIONS = [
-  { value: 'date', label: 'По дате' },
-  { value: 'price_asc', label: 'По цене (возрастание)' },
-  { value: 'price_desc', label: 'По цене (убывание)' },
-  { value: 'rating', label: 'По рейтингу' },
+  { value: '', label: 'Без сортировки' },
+  { value: 'price_low', label: 'По цене (возрастание)' },
+  { value: 'price_high', label: 'По цене (убывание)' },
+  { value: 'rating_low', label: 'По рейтингу (возрастание)' },
+  { value: 'rating_high', label: 'По рейтингу (убывание)' },
 ] as const;


### PR DESCRIPTION
## Summary
- update search sort keys to match backend API
- remove unused default sort

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684599eda0bc832ebd61f53fd6e72cc3